### PR TITLE
chore: add local docpact pre-push gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-03"
-lastReviewedCommit: "c7983661d396c5341acb1428ce77aa2e9c2e6b5e"
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7268905de463f749fabe020317c573c7f061c5b5
 
 catalog:
   repos:
@@ -39,8 +39,19 @@ ownership:
           - wechat.jpg
       ownerRepo: data
 
+    - id: local-docpact-push-gate
+      paths:
+        include:
+          - .githooks/**
+          - scripts/docpact-gate.sh
+          - scripts/install-git-hooks.sh
+      ownerRepo: data
+
 coverage:
   include:
+    - .githooks/**
+    - scripts/docpact-gate.sh
+    - scripts/install-git-hooks.sh
     - AGENTS.md
     - README.md
     - .docpact/config.yaml
@@ -63,6 +74,11 @@ freshness:
 
 routing:
   intents:
+    local-docpact-gate:
+      paths:
+        - .githooks/pre-push
+        - scripts/docpact-gate.sh
+        - scripts/install-git-hooks.sh
     dataset-content:
       paths:
         - tiangong_lca_data/**
@@ -196,3 +212,19 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
     reason: Documentation governance automation changes alter the maintenance gate and proof expectations.
+  - id: data-local-docpact-push-gate
+    scope: repo
+    repo: data
+    triggers:
+      - path: .githooks/pre-push
+        kind: local-git-hook
+      - path: scripts/docpact-gate.sh
+        kind: local-automation
+      - path: scripts/install-git-hooks.sh
+        kind: local-automation
+    requiredDocs:
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+    reason: Local push documentation governance gates must stay aligned with repo validation guidance and docpact configuration.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "$repo_root/scripts/docpact-gate.sh" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,11 @@ checkPaths:
   - release_notes/**
   - tiangong_lca_data/**
   - wechat.jpg
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: c7983661d396c5341acb1428ce77aa2e9c2e6b5e
+  - .githooks/**
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7268905de463f749fabe020317c573c7f061c5b5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md
@@ -102,3 +105,13 @@ If the data change must ship through the workspace:
 1. merge the child PR into `tiangong-lca-data`
 2. update the `lca-workspace` submodule pointer deliberately
 3. run any later workspace-level validation that depends on the new data snapshot
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -20,8 +20,11 @@ checkPaths:
   - schemas/**
   - stylesheets/**
   - release_notes/**
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: c7983661d396c5341acb1428ce77aa2e9c2e6b5e
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7268905de463f749fabe020317c573c7f061c5b5
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -52,3 +55,7 @@ Do not infer app behavior, TIDAS semantics, conversion logic, or workspace deliv
 ## Integration Semantics
 
 A merged PR in this repository is repo-complete only. If the dataset snapshot must ship through the workspace, the root workspace must deliberately update the `tiangong-lca-data` submodule pointer after merge.
+
+## Local Docpact Push Gate
+
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,11 @@ checkPaths:
   - schemas/**
   - stylesheets/**
   - release_notes/**
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: c7983661d396c5341acb1428ce77aa2e9c2e6b5e
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7268905de463f749fabe020317c573c7f061c5b5
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -54,3 +57,13 @@ The repository PR workflow runs the same docpact config validation and PR-shaped
 ## Future Automation
 
 If this repository gains a canonical data validation wrapper later, update this file, `AGENTS.md`, and `.docpact/config.yaml` in the same change.
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
+    printf '%s\n' "$DOCPACT_BIN"
+    return 0
+  fi
+
+  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
+    printf '%s\n' "$HOME/.cargo/bin/docpact"
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    command -v docpact
+    return 0
+  fi
+
+  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+docpact_bin="$(find_docpact)"
+current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+head_ref="${DOCPACT_HEAD_REF:-HEAD}"
+base_ref="${DOCPACT_BASE_REF:-origin/main}"
+
+case "$current_branch" in
+  main | master | promote/* | hotfix/* | release/*)
+    if [ -z "${DOCPACT_BASE_REF:-}" ]; then
+      base_ref="origin/main"
+    fi
+    ;;
+esac
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      base_ref="$2"
+      shift 2
+      ;;
+    --head)
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if ! base_sha="$(git merge-base "$head_ref" "$base_ref" 2>/dev/null)"; then
+  echo "Could not resolve merge-base for $head_ref and $base_ref." >&2
+  echo "Fetch the base ref or rerun with DOCPACT_BASE_REF=<ref>." >&2
+  exit 2
+fi
+
+head_sha="$(git rev-parse "$head_ref")"
+report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
+trap 'rm -f "$report_path"' EXIT HUP INT TERM
+
+echo "Running docpact config validation."
+"$docpact_bin" validate-config --root . --strict
+
+echo "Running docpact lint: base=$base_sha head=$head_sha."
+"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/docpact-gate.sh
+
+echo "Configured git hooks: core.hooksPath=.githooks"


### PR DESCRIPTION
Closes #14
Refs tiangong-lca/workspace#95

## Summary
- add a versioned local pre-push hook that runs docpact before pushing
- add scripts/docpact-gate.sh and scripts/install-git-hooks.sh
- update docpact config and validation guidance for the new local gate

## Key Decisions
- keep this as a lightweight docpact-only local push gate
- do not force heavyweight full validation on every feature-branch push
- write detailed docpact reports to a temporary file to avoid .docpact/runs worktree noise

## Validation
- docpact validate-config --root . --strict
- docpact lint --root . --staged --mode enforce
- scripts/docpact-gate.sh --base origin/main

## Risks / Rollback
Low risk. Revert the hook/script/config changes if local hook installation causes unexpected developer workflow issues.

## Workspace Integration
Requires a later lca-workspace submodule pointer bump tracked by tiangong-lca/workspace#95.
