### PR TITLE
chore: standardize docpact CLI wrapper

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -43,6 +43,7 @@ ownership:
       paths:
         include:
           - .githooks/**
+          - scripts/docpact
           - scripts/docpact-gate.sh
           - scripts/install-git-hooks.sh
       ownerRepo: data
@@ -50,6 +51,7 @@ ownership:
 coverage:
   include:
     - .githooks/**
+    - scripts/docpact
     - scripts/docpact-gate.sh
     - scripts/install-git-hooks.sh
     - AGENTS.md
@@ -77,6 +79,7 @@ routing:
     local-docpact-gate:
       paths:
         - .githooks/pre-push
+        - scripts/docpact
         - scripts/docpact-gate.sh
         - scripts/install-git-hooks.sh
     dataset-content:
@@ -218,6 +221,8 @@ rules:
     triggers:
       - path: .githooks/pre-push
         kind: local-git-hook
+      - path: scripts/docpact
+        kind: local-automation
       - path: scripts/docpact-gate.sh
         kind: local-automation
       - path: scripts/install-git-hooks.sh

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,14 +20,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.4 --force
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Validate docpact config
-        run: docpact validate-config --root . --strict
+        run: scripts/docpact validate-config --root . --strict
 
       - name: Run ai-doc-lint
         run: |
-          docpact lint \
+          scripts/docpact lint \
             --root . \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ checkPaths:
   - tiangong_lca_data/**
   - wechat.jpg
   - .githooks/**
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
@@ -87,7 +88,7 @@ Route those tasks to:
 - This repo is content-oriented; it does not currently define one canonical checked-in validation wrapper like `npm run lint` or `pytest`
 - Validation is therefore change-scoped: review touched data assets directly and verify structural expectations against bundled schema/style assets when relevant
 - Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`
-- For documentation-governance changes, run `docpact validate-config --root . --strict` and `docpact lint --root . --base origin/main --head HEAD --mode enforce`
+- For documentation-governance changes, run `scripts/docpact validate-config --root . --strict` and `scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce`
 - If future automation is added, document it in `AGENTS.md`, `.docpact/config.yaml`, and `docs/agents/repo-validation.md` in the same change
 
 ## Hard Boundaries
@@ -114,4 +115,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,6 +21,7 @@ checkPaths:
   - stylesheets/**
   - release_notes/**
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
@@ -58,4 +59,4 @@ A merged PR in this repository is repo-complete only. If the dataset snapshot mu
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,6 +22,7 @@ checkPaths:
   - stylesheets/**
   - release_notes/**
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
@@ -48,8 +49,8 @@ This repository is content-oriented and does not currently define a single check
 Run these commands for governance changes:
 
 ```bash
-docpact validate-config --root . --strict
-docpact lint --root . --base origin/main --head HEAD --mode enforce
+scripts/docpact validate-config --root . --strict
+scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce
 ```
 
 The repository PR workflow runs the same docpact config validation and PR-shaped lint gate.
@@ -66,4 +67,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/scripts/docpact
+++ b/scripts/docpact
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+docpact_version="${DOCPACT_VERSION:-0.1.9}"
+
+use_candidate() {
+  candidate="$1"
+  if [ -n "$candidate" ] && [ -x "$candidate" ] && "$candidate" --version >/dev/null 2>&1; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ]; then
+    if use_candidate "$DOCPACT_BIN"; then
+      return 0
+    fi
+    echo "DOCPACT_BIN is set but is not an executable docpact binary: $DOCPACT_BIN" >&2
+    return 127
+  fi
+
+  if [ -n "${CARGO_HOME:-}" ] && use_candidate "$CARGO_HOME/bin/docpact"; then
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && use_candidate "$HOME/.cargo/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/opt/homebrew/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/usr/local/bin/docpact"; then
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    candidate="$(command -v docpact)"
+    case "$candidate" in
+      */scripts/docpact | scripts/docpact | ./scripts/docpact)
+        ;;
+      *)
+        if use_candidate "$candidate"; then
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  echo "docpact was not found." >&2
+  echo "Install it with: cargo install docpact --version $docpact_version --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+if [ "${1:-}" = "--print-bin" ]; then
+  find_docpact
+  exit 0
+fi
+
+docpact_bin="$(find_docpact)"
+exec "$docpact_bin" "$@"

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -4,28 +4,7 @@ set -eu
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-find_docpact() {
-  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
-    printf '%s\n' "$DOCPACT_BIN"
-    return 0
-  fi
-
-  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
-    printf '%s\n' "$HOME/.cargo/bin/docpact"
-    return 0
-  fi
-
-  if command -v docpact >/dev/null 2>&1; then
-    command -v docpact
-    return 0
-  fi
-
-  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
-  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
-  return 127
-}
-
-docpact_bin="$(find_docpact)"
+docpact_cmd="$repo_root/scripts/docpact"
 current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 head_ref="${DOCPACT_HEAD_REF:-HEAD}"
 base_ref="${DOCPACT_BASE_REF:-origin/main}"
@@ -65,7 +44,7 @@ report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
 trap 'rm -f "$report_path"' EXIT HUP INT TERM
 
 echo "Running docpact config validation."
-"$docpact_bin" validate-config --root . --strict
+"$docpact_cmd" validate-config --root "$repo_root" --strict
 
 echo "Running docpact lint: base=$base_sha head=$head_sha."
-"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"
+"$docpact_cmd" lint --root "$repo_root" --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -5,6 +5,6 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/docpact-gate.sh
+chmod +x .githooks/pre-push scripts/docpact scripts/docpact-gate.sh
 
 echo "Configured git hooks: core.hooksPath=.githooks"


### PR DESCRIPTION
## Summary
- add a repo-local `scripts/docpact` wrapper for local CLI discovery
- route local docpact gates and CI doc-governance checks through the wrapper
- update docpact install guidance to the confirmed stable 0.1.9 release
- refresh repo-local governance docs so submodule working directories no longer depend on bare `docpact` being on `PATH`

## Validation
- `scripts/docpact validate-config --root <repo> --strict`
- `scripts/docpact lint --root <repo> --worktree --mode enforce`
- local docpact gate against the target base branch

No tracked issue was provided; this PR records the user-requested batch governance standardization.
